### PR TITLE
Updare start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"main": "node_modules/expo/AppEntry.js",
 	"scripts": {
-		"start": "expo start",
+		"start": "expo start --tunnel",
 		"android": "expo start --android",
 		"ios": "expo start --ios",
 		"web": "expo start --web",


### PR DESCRIPTION
The developer dashboard takes a long time to load since it is loaded in the browser, and I cannot seem to download the app unless the connection is set to tunnel. By setting this flag, development will be faster for those who want disable the developer dashboard and work straight from the terminal.