### PR TITLE
move API response type definitions into common module, closes #94

### DIFF
--- a/api-server/api.ts
+++ b/api-server/api.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { createWorker } from "tesseract.js";
 import multer from "multer";
+import type { MonocleApiResponse } from "../common/api";
 
 const worker = createWorker({
 	logger: m => console.log(m),
@@ -18,22 +19,6 @@ void (async () => {
 
 const storage = multer.memoryStorage();
 const upload = multer({ storage: storage, limits: { fieldSize: 10 * 1024 * 1024 } });
-
-// TODO: move these interfaces to a seperate module so that they can be reused on the client side.
-interface ResponseSuccess<T = undefined> {
-	success: true;
-	result: T;
-}
-
-interface ResponseError {
-	success: false;
-	error: {
-		name: string;
-		message: string;
-	};
-}
-
-export type MonocleApiResponse<T = undefined> = ResponseSuccess<T> | ResponseError;
 
 export const apirouter = express.Router();
 

--- a/common/.eslintrc.js
+++ b/common/.eslintrc.js
@@ -1,0 +1,44 @@
+module.exports = {
+	root: true,
+	plugins: ["@typescript-eslint"],
+	env: {
+		node: true,
+	},
+	parser: "@typescript-eslint/parser",
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: "module",
+		ecmaFeatures: {
+			jsx: false,
+		},
+	},
+	settings: {
+		react: {
+			version: "detect",
+		},
+	},
+	extends: ["plugin:@typescript-eslint/recommended"],
+	overrides: [
+		{
+			files: ["*.ts", "*.tsx"],
+			extends: ["plugin:@typescript-eslint/recommended-requiring-type-checking"],
+			parserOptions: {
+				project: ["./tsconfig.json"],
+			},
+			rules: {
+				"@typescript-eslint/switch-exhaustiveness-check": "error",
+			},
+		},
+	],
+	// Do NOT use any eslint ruels that affect code formatting because prettier handles that.
+	rules: {
+		"no-console": "warn",
+		"no-debugger": "error",
+		"no-var": "error",
+		"eqeqeq": "error",
+		"prettier/prop-types": "off",
+		"@typescript-eslint/no-var-requires": "error",
+		"@typescript-eslint/adjacent-overload-signatures": "error",
+		"@typescript-eslint/no-extra-semi": "off",
+	},
+};

--- a/common/api.ts
+++ b/common/api.ts
@@ -1,0 +1,14 @@
+interface ResponseSuccess<T = undefined> {
+	success: true;
+	result: T;
+}
+
+interface ResponseError {
+	success: false;
+	error: {
+		name: string;
+		message: string;
+	};
+}
+
+export type MonocleApiResponse<T = undefined> = ResponseSuccess<T> | ResponseError;

--- a/common/package.json
+++ b/common/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "monocle-common",
+	"version": "0.1.0",
+	"scripts": {
+		"lint": "tsc --noEmit && eslint --config .eslintrc.js --fix . && prettier --config prettier.config.js --write \"**/*.{js,jsx,json,ts,tsx,md,mdx,css,html,yml,yaml,scss}\""
+	}
+}

--- a/common/prettier.config.js
+++ b/common/prettier.config.js
@@ -1,0 +1,28 @@
+module.exports = {
+	arrowParens: "avoid",
+	bracketSameLine: false,
+	bracketSpacing: true,
+	embeddedLanguageFormatting: "auto",
+	htmlWhitespaceSensitivity: "css",
+	insertPragma: false,
+	jsxSingleQuote: false,
+	printWidth: 100,
+	proseWrap: "preserve",
+	quoteProps: "consistent",
+	requirePragma: false,
+	semi: true,
+	singleQuote: false,
+	tabWidth: 4,
+	trailingComma: "es5",
+	useTabs: true,
+	vueIndentScriptAndStyle: false,
+	overrides: [
+		{
+			files: ["*.yaml", "*.yml"],
+			options: {
+				useTabs: false,
+				tabWidth: 2,
+			},
+		},
+	],
+};

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"strictNullChecks": true
+	}
+}

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
 	"license": "GPL3.0-OR-LATER",
 	"private": true,
 	"workspaces": [
+		"common",
 		"front-end",
 		"api-server"
 	],
 	"scripts": {
 		"start": "yarn workspace monocle-front-end start",
-		"lint": "yarn workspace monocle-front-end lint && yarn workspace monocle-api-server lint",
+		"api": "yarn workspace monocle-api-server api",
+		"lint": "yarn workspaces run lint",
 		"test": "yarn workspace monocle-front-end test && yarn workspace monocle-api-server test"
 	}
 }


### PR DESCRIPTION
This has a very high chance to break the heroku deployments. I'll fix it when this gets merged.﻿
